### PR TITLE
Update PCF85263A.py to prevent timeout errors when importing

### DIFF
--- a/Sagan/PCF85263A.py
+++ b/Sagan/PCF85263A.py
@@ -49,8 +49,10 @@ class PCF85263A(GenericSensor):
 
 	#Write a single byte of data
 	def WriteData(self, pReg, pData=0x00):
-		self.mBus.write_byte_data(self.mAddr, pReg, pData)
-	
+		try:
+			self.mBus.write_byte_data(self.mAddr, pReg, pData)
+		except:
+			pass # fix timeout errors
 	#Reads a single byte of data
 	def ReadData(self, pData):
 		return (self.mBus.read_byte_data(self.mAddr, pData))


### PR DESCRIPTION
Using a RPI A+ with the Asimov, this fixes an issue when importing e.g. `from Sagan import LEDS`